### PR TITLE
update mod path so we can install our own version

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/brutella/dnssd"
+	"github.com/decent-e/dnssd"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
-module github.com/brutella/dnssd
+module github.com/decent-e/dnssd
 
 require (
+	github.com/brutella/dnssd v1.2.4
 	github.com/miekg/dns v1.1.50
 	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/brutella/dnssd v1.2.4 h1:hmSHQnUS5qujI8PX1QKHDhmwzZVvd63YINFfF9jcGfE=
+github.com/brutella/dnssd v1.2.4/go.mod h1:JoW2sJUrmVIef25G6lrLj7HS6Xdwh6q8WUIvMkkBYXs=
 github.com/miekg/dns v1.1.50 h1:DQUfb9uc6smULcREF09Uc+/Gd46YWqJd5DbpPE9xkcA=
 github.com/miekg/dns v1.1.50/go.mod h1:e3IlAVfNqAllflbibAZEWOXOQ+Ynzk/dDozDxY7XnME=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=


### PR DESCRIPTION
go install really wants github url to match what's in go.mod so switch up our fork to use our branch where required.

Signed-off-by: Eric Van Hensbergen <ericvh@gmail.com>